### PR TITLE
Register secondaries in pg_dist_node

### DIFF
--- a/features/citus.feature
+++ b/features/citus.feature
@@ -10,20 +10,24 @@ Feature: citus
     And I start postgres3 in citus group 1
     Then replication works from postgres0 to postgres1 after 15 seconds
     Then replication works from postgres2 to postgres3 after 15 seconds
-    And postgres0 is registered in the postgres0 as the worker in group 0
-    And postgres2 is registered in the postgres0 as the worker in group 1
+    And postgres0 is registered in the postgres0 as the primary in group 0 after 5 seconds
+    And postgres1 is registered in the postgres0 as the secondary in group 0 after 5 seconds
+    And postgres2 is registered in the postgres0 as the primary in group 1 after 5 seconds
+    And postgres3 is registered in the postgres0 as the secondary in group 1 after 5 seconds
 
   Scenario: coordinator failover updates pg_dist_node
     Given I run patronictl.py failover batman --group 0 --candidate postgres1 --force
     Then postgres1 role is the primary after 10 seconds
     And replication works from postgres1 to postgres0 after 15 seconds
     And "sync" key in a group 0 in DCS has sync_standby=postgres0 after 15 seconds
-    And postgres1 is registered in the postgres2 as the worker in group 0
+    And postgres1 is registered in the postgres2 as the primary in group 0 after 5 seconds
+    And postgres0 is registered in the postgres2 as the secondary in group 0 after 15 seconds
     When I run patronictl.py failover batman --group 0 --candidate postgres0 --force
     Then postgres0 role is the primary after 10 seconds
     And replication works from postgres0 to postgres1 after 15 seconds
     And "sync" key in a group 0 in DCS has sync_standby=postgres1 after 15 seconds
-    And postgres0 is registered in the postgres2 as the worker in group 0
+    And postgres0 is registered in the postgres2 as the primary in group 0 after 5 seconds
+    And postgres1 is registered in the postgres2 as the secondary in group 0 after 15 seconds
 
   Scenario: worker switchover doesn't break client queries on the coordinator
     Given I create a distributed table on postgres0
@@ -33,14 +37,16 @@ Feature: citus
     And postgres3 role is the primary after 10 seconds
     And replication works from postgres3 to postgres2 after 15 seconds
     And "sync" key in a group 1 in DCS has sync_standby=postgres2 after 15 seconds
-    And postgres3 is registered in the postgres0 as the worker in group 1
+    And postgres3 is registered in the postgres0 as the primary in group 1 after 5 seconds
+    And postgres2 is registered in the postgres0 as the secondary in group 1 after 15 seconds
     And a thread is still alive
     When I run patronictl.py switchover batman --group 1 --force
     Then I receive a response returncode 0
     And postgres2 role is the primary after 10 seconds
     And replication works from postgres2 to postgres3 after 15 seconds
     And "sync" key in a group 1 in DCS has sync_standby=postgres3 after 15 seconds
-    And postgres2 is registered in the postgres0 as the worker in group 1
+    And postgres2 is registered in the postgres0 as the primary in group 1 after 5 seconds
+    And postgres3 is registered in the postgres0 as the secondary in group 1 after 15 seconds
     And a thread is still alive
     When I stop a thread
     Then a distributed table on postgres0 has expected rows
@@ -52,7 +58,8 @@ Feature: citus
     Then I receive a response returncode 0
     And postgres2 role is the primary after 10 seconds
     And replication works from postgres2 to postgres3 after 15 seconds
-    And postgres2 is registered in the postgres0 as the worker in group 1
+    And postgres2 is registered in the postgres0 as the primary in group 1 after 5 seconds
+    And postgres3 is registered in the postgres0 as the secondary in group 1 after 15 seconds
     And a thread is still alive
     When I stop a thread
     Then a distributed table on postgres0 has expected rows
@@ -64,8 +71,7 @@ Feature: citus
     When I run patronictl.py edit-config batman --group 2 -s ttl=20 --force
     Then I receive a response returncode 0
     And I receive a response output "+ttl: 20"
-    When I sleep for 2 seconds
-    Then postgres4 is registered in the postgres2 as the worker in group 2
+    Then postgres4 is registered in the postgres2 as the primary in group 2 after 5 seconds
     When I shut down postgres4
     Then There is a transaction in progress on postgres0 changing pg_dist_node
     When I run patronictl.py restart batman postgres2 --group 1 --force

--- a/patroni/postgresql/citus.py
+++ b/patroni/postgresql/citus.py
@@ -40,7 +40,7 @@ class PgDistNode:
     def __repr__(self) -> str:
         return str(self)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.host, self.port))
 
     def is_primary(self) -> bool:
@@ -77,8 +77,8 @@ class PgDistGroup(Set[PgDistNode]):
         assert new_primary is not None
         old_primary = old.primary()
 
-        gone_nodes = old - self - set([old_primary])
-        added_nodes = self - old - set([new_primary])
+        gone_nodes = old - self - {old_primary}
+        added_nodes = self - old - {new_primary}
 
         if not old_primary:
             yield new_primary
@@ -130,7 +130,7 @@ class PgDistGroup(Set[PgDistNode]):
             yield new_primary
 
             # The new primary was never registered as a standby and there are secondaries that gone away.
-            # Since nodes can't be removed while metadate isn't synced we have to temporary "add" the old primary back.
+            # Since nodes can't be removed while metadata isn't synced we have to temporary "add" the old primary back.
             if not new_primary_old_node and gone_nodes:
                 # We were in the middle of controlled switchover while the primary disappeared.
                 # If there are any gone nodes that can't be reused for new secondaries we will

--- a/patroni/postgresql/citus.py
+++ b/patroni/postgresql/citus.py
@@ -339,9 +339,7 @@ class CitusHandler(Thread):
                     if i is None:
                         break
                     task = self._tasks[i]
-                    if task.group in self._pg_dist_group\
-                            and task.event == self._pg_dist_group[task.group].event\
-                            and task.equals(self._pg_dist_group[task.group]):
+                    if task == self._pg_dist_group.get(task.group):
                         self._tasks.pop(i)  # nothing to do because cached version of pg_dist_group already matches
                     else:
                         break
@@ -483,9 +481,7 @@ class CitusHandler(Thread):
                     self._condition.notify()
                     return True
             # Add the task to the list if Worker node state is different from the cached `pg_dist_group`
-            elif self._schedule_load_pg_dist_group\
-                    or task.group not in self._pg_dist_group\
-                    or task != self._pg_dist_group[task.group]\
+            elif self._schedule_load_pg_dist_group or task != self._pg_dist_group.get(task.group)\
                     or self._in_flight and task.group == self._in_flight.group:
                 logger.debug('Adding the new task: %s', task)
                 self._tasks.append(task)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -137,8 +137,12 @@ class MockCursor(object):
                                  b'3\t0/403DD98\tno recovery target specified\n')]
         elif sql.startswith('SELECT pg_catalog.citus_add_node'):
             self.results = [(2,)]
-        elif sql.startswith('SELECT nodeid, groupid'):
-            self.results = [(1, 0, 'host1', 5432, 'primary'), (2, 1, 'host2', 5432, 'primary')]
+        elif sql.startswith('SELECT groupid, nodename'):
+            self.results = [(0, 'host1', 5432, 'primary', 1),
+                            (0, '127.0.0.1', 5436, 'secondary', 2),
+                            (1, 'host4', 5432, 'primary', 3),
+                            (1, '127.0.0.1', 5437, 'secondary', 4),
+                            (1, '127.0.0.1', 5438, 'secondary', 5)]
         else:
             self.results = [(None, None, None, None, None, None, None, None, None, None)]
 

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -1,6 +1,10 @@
 import time
+import unittest
+
+from copy import deepcopy
 from mock import Mock, patch
-from patroni.postgresql.citus import CitusHandler
+from typing import List
+from patroni.postgresql.citus import CitusHandler, PgDistGroup, PgDistNode
 
 from . import BaseTestPostgresql, MockCursor, psycopg_connect, SleepException
 from .test_ha import get_cluster_initialized_with_leader
@@ -20,7 +24,7 @@ class TestCitus(BaseTestPostgresql):
     @patch('time.time', Mock(side_effect=[100, 130, 160, 190, 220, 250, 280, 310, 340, 370]))
     @patch('patroni.postgresql.citus.logger.exception', Mock(side_effect=SleepException))
     @patch('patroni.postgresql.citus.logger.warning')
-    @patch('patroni.postgresql.citus.PgDistNode.wait', Mock())
+    @patch('patroni.postgresql.citus.PgDistTask.wait', Mock())
     @patch.object(CitusHandler, 'is_alive', Mock(return_value=True))
     def test_run(self, mock_logger_warning):
         # `before_demote` or `before_promote` REST API calls starting a
@@ -32,11 +36,11 @@ class TestCitus(BaseTestPostgresql):
 
         self.c.handle_event(self.cluster, {'type': 'before_demote', 'group': 1,
                                            'leader': 'leader', 'timeout': 30, 'cooldown': 10})
-        self.c.add_task('after_promote', 2, 'postgres://host3:5432/postgres')
+        self.c.add_task('after_promote', 2, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
         self.assertRaises(SleepException, self.c.run)
         mock_logger_warning.assert_called_once()
         self.assertTrue(mock_logger_warning.call_args[0][0].startswith('Rolling back transaction'))
-        self.assertTrue(repr(mock_logger_warning.call_args[0][1]).startswith('PgDistNode'))
+        self.assertTrue(repr(mock_logger_warning.call_args[0][1]).startswith('PgDistTask'))
 
     @patch.object(CitusHandler, 'is_alive', Mock(return_value=False))
     @patch.object(CitusHandler, 'start', Mock())
@@ -54,59 +58,68 @@ class TestCitus(BaseTestPostgresql):
     def test_add_task(self):
         with patch('patroni.postgresql.citus.logger.error') as mock_logger,\
                 patch('patroni.postgresql.citus.urlparse', Mock(side_effect=Exception)):
-            self.c.add_task('', 1, None)
+            self.c.add_task('', 1, self.cluster, '', None)
             mock_logger.assert_called_once()
 
         with patch('patroni.postgresql.citus.logger.debug') as mock_logger:
-            self.c.add_task('before_demote', 1, 'postgres://host:5432/postgres', 30)
+            self.c.add_task('before_demote', 1, self.cluster,
+                            self.cluster.leader_name, 'postgres://host:5432/postgres', 30)
             mock_logger.assert_called_once()
             self.assertTrue(mock_logger.call_args[0][0].startswith('Adding the new task:'))
 
         with patch('patroni.postgresql.citus.logger.debug') as mock_logger:
-            self.c.add_task('before_promote', 1, 'postgres://host:5432/postgres', 30)
+            self.c.add_task('before_promote', 1, self.cluster,
+                            self.cluster.leader_name, 'postgres://host:5432/postgres', 30)
             mock_logger.assert_called_once()
             self.assertTrue(mock_logger.call_args[0][0].startswith('Overriding existing task:'))
 
         # add_task called from sync_pg_dist_node should not override already scheduled or in flight task until deadline
-        self.assertIsNotNone(self.c.add_task('after_promote', 1, 'postgres://host:5432/postgres', 30))
-        self.assertIsNone(self.c.add_task('after_promote', 1, 'postgres://host:5432/postgres'))
+        self.assertIsNotNone(self.c.add_task('after_promote', 1, self.cluster,
+                                             self.cluster.leader_name, 'postgres://host:5432/postgres', 30))
+        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+                                          self.cluster.leader_name, 'postgres://host:5432/postgres'))
         self.c._in_flight = self.c._tasks.pop()
         self.c._in_flight.deadline = self.c._in_flight.timeout + time.time()
-        self.assertIsNone(self.c.add_task('after_promote', 1, 'postgres://host:5432/postgres'))
+        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+                                          self.cluster.leader_name, 'postgres://host:5432/postgres'))
         self.c._in_flight.deadline = 0
-        self.assertIsNotNone(self.c.add_task('after_promote', 1, 'postgres://host:5432/postgres'))
+        self.assertIsNotNone(self.c.add_task('after_promote', 1, self.cluster,
+                                             self.cluster.leader_name, 'postgres://host:5432/postgres'))
 
         # If there is no transaction in progress and cached pg_dist_node matching desired state task should not be added
         self.c._schedule_load_pg_dist_node = False
-        self.c._pg_dist_node[self.c._in_flight.group] = self.c._in_flight
+        self.c._pg_dist_group[self.c._in_flight.group] = self.c._in_flight
         self.c._in_flight = None
-        self.assertIsNone(self.c.add_task('after_promote', 1, 'postgres://host:5432/postgres'))
+        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+                                          self.cluster.leader_name, 'postgres://host:5432/postgres'))
 
     def test_pick_task(self):
-        self.c.add_task('after_promote', 1, 'postgres://host2:5432/postgres')
-        with patch.object(CitusHandler, 'process_task') as mock_process_task:
+        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host1:5432/postgres')
+        with patch.object(CitusHandler, 'update_node') as mock_update_node:
             self.c.process_tasks()
-            # process_task() shouln't be called because pick_task double checks with _pg_dist_node
-            mock_process_task.assert_not_called()
+            # process_task() shouln't be called because pick_task double checks with _pg_dist_group
+            mock_update_node.assert_not_called()
 
     def test_process_task(self):
-        self.c.add_task('after_promote', 0, 'postgres://host2:5432/postgres')
-        task = self.c.add_task('before_promote', 1, 'postgres://host4:5432/postgres', 30)
+        self.c.add_task('after_promote', 1, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
+        task = self.c.add_task('before_promote', 1, self.cluster,
+                               self.cluster.leader_name, 'postgres://host4:5432/postgres', 30)
         self.c.process_tasks()
         self.assertTrue(task._event.is_set())
 
         # the after_promote should result only in COMMIT
-        task = self.c.add_task('after_promote', 1, 'postgres://host4:5432/postgres', 30)
+        task = self.c.add_task('after_promote', 1, self.cluster,
+                               self.cluster.leader_name, 'postgres://host4:5432/postgres', 30)
         with patch.object(CitusHandler, 'query') as mock_query:
             self.c.process_tasks()
             mock_query.assert_called_once()
             self.assertEqual(mock_query.call_args[0][0], 'COMMIT')
 
     def test_process_tasks(self):
-        self.c.add_task('after_promote', 0, 'postgres://host2:5432/postgres')
+        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
         self.c.process_tasks()
 
-        self.c.add_task('after_promote', 0, 'postgres://host3:5432/postgres')
+        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
         with patch('patroni.postgresql.citus.logger.error') as mock_logger,\
                 patch.object(CitusHandler, 'query', Mock(side_effect=Exception)):
             self.c.process_tasks()
@@ -118,16 +131,17 @@ class TestCitus(BaseTestPostgresql):
 
     @patch('patroni.postgresql.citus.logger.error')
     @patch.object(MockCursor, 'execute', Mock(side_effect=Exception))
-    def test_load_pg_dist_node(self, mock_logger):
-        # load_pg_dist_node() triggers, query fails and exception is property handled
+    def test_load_pg_dist_group(self, mock_logger):
+        # load_pg_dist_group) triggers, query fails and exception is property handled
         self.c.process_tasks()
-        self.assertTrue(self.c._schedule_load_pg_dist_node)
+        self.assertTrue(self.c._schedule_load_pg_dist_group)
         mock_logger.assert_called_once()
         self.assertTrue(mock_logger.call_args[0][0].startswith('Exception when executing query'))
-        self.assertTrue(mock_logger.call_args[0][1].startswith('SELECT nodeid, groupid, '))
+        self.assertTrue(mock_logger.call_args[0][1].startswith('SELECT groupid, nodename, '))
 
     def test_wait(self):
-        task = self.c.add_task('before_demote', 1, 'postgres://host:5432/postgres', 30)
+        task = self.c.add_task('before_demote', 1, self.cluster,
+                               self.cluster.leader_name, u'postgres://host:5432/postgres', 30)
         task._event.wait = Mock()
         task.wait()
 
@@ -161,3 +175,198 @@ class TestCitus(BaseTestPostgresql):
                                                          'type': 'logical', 'database': 'citus', 'plugin': 'pgoutput'}))
         self.assertTrue(self.c.ignore_replication_slot({'name': 'citus_shard_split_slot_1_2_3',
                                                         'type': 'logical', 'database': 'citus', 'plugin': 'citus'}))
+
+
+class TestGroupTransition(unittest.TestCase):
+    nodeid = 100
+
+    def map_to_sql(self, transition: PgDistNode) -> str:
+        if transition.role not in ('primary', 'demoted', 'secondary'):
+            return "citus_remove_node('{0}', {1})".format(transition.host, transition.port)
+        elif transition.nodeid:
+            host = transition.host + ('-demoted' if transition.role == 'demoted' else '')
+            return "citus_update_node({0}, '{1}', {2})".format(transition.nodeid, host, transition.port)
+        else:
+            transition.nodeid = self.nodeid
+            self.nodeid += 1
+
+            return "citus_add_node('{0}', {1}, {2}, '{3}')".format(transition.host, transition.port,
+                                                                   transition.group, transition.role)
+
+    def check_transitions(self, old_topology: PgDistGroup, new_topology: PgDistGroup,
+                          expected_transitions: List[str]) -> None:
+        check_topology = deepcopy(old_topology)
+
+        transitions: List[str] = []
+        for node in new_topology.transition(old_topology):
+            self.assertTrue(node not in check_topology or (check_topology.get(node) or node).role == 'demoted')
+            old_node = node.nodeid and next(iter(v for v in check_topology if v.nodeid == node.nodeid), None)
+            if old_node:
+                check_topology.discard(old_node)
+            transitions.append(self.map_to_sql(node))
+            check_topology.add(node)
+        self.assertEqual(transitions, expected_transitions)
+
+    def test_new_topology(self):
+        old = PgDistGroup(0)
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary'),
+                              PgDistNode(0, '2', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=100),
+                                   PgDistNode(0, '2', 5432, 'secondary', nodeid=101)})
+        self.check_transitions(old, new,
+                               ["citus_add_node('1', 5432, 0, 'primary')",
+                                "citus_add_node('2', 5432, 0, 'secondary')"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary'),
+                              PgDistNode(0, '2', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '1', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new,
+                               ["citus_update_node(1, '1-demoted', 5432)",
+                                "citus_update_node(2, '1', 5432)",
+                                "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_failover(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '1', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new,
+                               ["citus_update_node(1, '1-demoted', 5432)",
+                                "citus_update_node(2, '1', 5432)",
+                                "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_failover_and_new_secondary(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary'),
+                              PgDistNode(0, '3', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '3', 5432, 'secondary', nodeid=2)})
+        # the secondary record is used to add the new standby and primary record is updated with the new hostname
+        self.check_transitions(old, new, ["citus_update_node(2, '3', 5432)", "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_secondary_replaced(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary'),
+                              PgDistNode(0, '3', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '3', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new, ["citus_update_node(2, '3', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_secondary_repmoved(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2),
+                              PgDistNode(0, '3', 5432, 'secondary', nodeid=3)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary'),
+                              PgDistNode(0, '3', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '3', 5432, 'secondary', nodeid=3)})
+        self.check_transitions(old, new, ["citus_remove_node('2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_and_secondary_removed(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2),
+                              PgDistNode(0, '3', 5432, 'secondary', nodeid=3)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary'),
+                              PgDistNode(0, '2', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary', nodeid=2),
+                                   PgDistNode(0, '2', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '3', 5432, 'secondary', nodeid=3)})
+        self.check_transitions(old, new,
+                               ["citus_update_node(1, '1-demoted', 5432)",
+                                "citus_update_node(2, '1', 5432)",
+                                "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_and_new_secondary(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary'),
+                              PgDistNode(0, '2', 5432, 'primary'),
+                              PgDistNode(0, '3', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary', nodeid=2),
+                                   PgDistNode(0, '2', 5432, 'primary', nodeid=1)})
+        self.check_transitions(old, new,
+                               ["citus_update_node(1, '1-demoted', 5432)",
+                                "citus_update_node(2, '1', 5432)",
+                                "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_failover_to_new_node_secondary_remains(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'secondary'),
+                              PgDistNode(0, '3', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '3', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new, ["citus_update_node(1, '3', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_failover_to_new_node_secondary_removed(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '3', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '3', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        # the secondary record needs to be removed before we update the primary record
+        self.check_transitions(old, new, ["citus_update_node(1, '3', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_to_new_node_and_secondary_removed(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary'),
+                              PgDistNode(0, '3', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '3', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '1', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new, ["citus_update_node(1, '3', 5432)", "citus_update_node(2, '1', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_with_pause(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted', nodeid=1),
+                                   PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        self.check_transitions(old, new, ["citus_update_node(1, '1-demoted', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_after_paused_connections(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary', nodeid=2),
+                                   PgDistNode(0, '2', 5432, 'primary', nodeid=1)})
+        self.check_transitions(old, new, ["citus_update_node(2, '1', 5432)", "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_to_new_node_after_paused_connections(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '3', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'secondary', nodeid=2),
+                                   PgDistNode(0, '3', 5432, 'primary', nodeid=1)})
+        self.check_transitions(old, new, ["citus_update_node(1, '3', 5432)", "citus_update_node(2, '1', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
+    def test_switchover_to_new_node_after_paused_connections_secondary_added(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '4', 5432, 'secondary'),
+                              PgDistNode(0, '3', 5432, 'primary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '4', 5432, 'secondary', nodeid=2),
+                                   PgDistNode(0, '3', 5432, 'primary', nodeid=1)})
+        self.check_transitions(old, new, ["citus_update_node(1, '3', 5432)", "citus_update_node(2, '4', 5432)"])
+        self.assertTrue(new.equals(expected, True))

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -254,6 +254,17 @@ class TestGroupTransition(unittest.TestCase):
         self.check_transitions(old, new, ["citus_update_node(2, '3', 5432)", "citus_update_node(1, '2', 5432)"])
         self.assertTrue(new.equals(expected, True))
 
+    def test_switchover_and_new_secondary_primary_gone(self):
+        old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'demoted', nodeid=1),
+                              PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})
+        new = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary'),
+                              PgDistNode(0, '3', 5432, 'secondary')})
+        expected = PgDistGroup(0, {PgDistNode(0, '2', 5432, 'primary', nodeid=1),
+                                   PgDistNode(0, '3', 5432, 'secondary', nodeid=2)})
+        # the secondary record is used to add the new standby and primary record is updated with the new hostname
+        self.check_transitions(old, new, ["citus_update_node(2, '3', 5432)", "citus_update_node(1, '2', 5432)"])
+        self.assertTrue(new.equals(expected, True))
+
     def test_secondary_replaced(self):
         old = PgDistGroup(0, {PgDistNode(0, '1', 5432, 'primary', nodeid=1),
                               PgDistNode(0, '2', 5432, 'secondary', nodeid=2)})


### PR DESCRIPTION
1. All nodes with role == 'replica' and state == 'running' are registered. In case is state isn't running the node is removed.
2. In case of failover/switchover we always first update the primary
3. When switching to a registered secondary we call citus_update_node() three times: rename primary to primary-demoted, put the primary name to a promoted secondary row and put the promoted secondary name to the primary row

State transitions are produced by the transition() method. First of all the method makes sure that the actual primary is registered in the metadata. In case if for a given group the primary didn't change, the method registers new secondaries and removes secondaries that are gone. It prefers to use citus_update_node() UDF to replace gone secondaries with added.

Communication protocol between primary nodes remains the same and all old features work without any changes.